### PR TITLE
Assorted updates for new libraries, and a few bug fixes

### DIFF
--- a/bin/bpm/blowout_obj.py
+++ b/bin/bpm/blowout_obj.py
@@ -31,11 +31,11 @@ if __name__ == '__main__':
     # uniform currents
     try:
         # Open the BM54 CTD profile if it exists
-        nc = '../../test/output/test_BM54.nc'
+        nc = '../../tamoc/test/output/test_BM54.nc'
         ctd = ambient.Profile(nc, chem_names='all')
         
         # Insert a constant crossflow velocity
-        z = ctd.nc.variables['z'][:]
+        z = ctd.data.variables['z'][:]
         ua = np.zeros(z.shape) + 0.09
         data = np.vstack((z, ua)).transpose()
         symbols = ['z', 'ua']

--- a/tamoc/ambient.py
+++ b/tamoc/ambient.py
@@ -87,6 +87,9 @@ from scipy.interpolate import interp1d
 
 import matplotlib.pyplot as plt
 
+import warnings
+
+
 
 class BaseProfile(object):
     """
@@ -767,7 +770,11 @@ class BaseProfile(object):
         self.ds[parm].plot(y=self.ztsp[0])
         if plt.ylim()[0] <= 0:
             plt.gca().invert_yaxis()
-        plt.tight_layout()
+        with warnings.catch_warnings():
+            # tight_layout() is raising an annoying warning
+            # this suppresses it
+            warnings.simplefilter("ignore", UserWarning)
+            plt.tight_layout()
     
     def plot_profiles(self, parameters, fig=1):
         """
@@ -806,8 +813,11 @@ class BaseProfile(object):
         for parm in parameters:
             ax = plt.subplot(nrows, 3, parameters.index(parm)+1)
             self.plot_parameter(parm)
-        
-        plt.tight_layout()
+        with warnings.catch_warnings():
+            # tight_layout() is raising an annoying warning
+            # this suppresses it
+            warnings.simplefilter("ignore", UserWarning)
+            plt.tight_layout()
     
     def plot_physical_profiles(self, fig=2):
         """

--- a/tamoc/bent_plume_model.py
+++ b/tamoc/bent_plume_model.py
@@ -2858,7 +2858,9 @@ def plot_state_space(t, q, q_local, profile, p, particles, fig):
     ax1.set_xlabel('x (m)')
     ax1.set_ylabel('Depth (m)')
     ax1.invert_yaxis()
-    ax1.grid(b=True, which='major', color='0.65', linestyle='-')
+    #ax1.grid(b=True, which='major', color='0.65', linestyle='-')
+    # b no longer a valid keyword -- what replaced it???
+    ax1.grid(which='major', color='0.65', linestyle='-')
 
     # y-z plane
     ax2 = plt.subplot(222)
@@ -2868,7 +2870,8 @@ def plot_state_space(t, q, q_local, profile, p, particles, fig):
     ax2.set_xlabel('y (m)')
     ax2.set_ylabel('Depth (m)')
     ax2.invert_yaxis()
-    ax2.grid(b=True, which='major', color='0.65', linestyle='-')
+    # b no longer a valid keyword -- what replaced it???
+    ax2.grid(which='major', color='0.65', linestyle='-')
 
     # x-y plane
     ax3 = plt.subplot(223)
@@ -2877,14 +2880,18 @@ def plot_state_space(t, q, q_local, profile, p, particles, fig):
         ax3.plot(xp[:,i*3], xp[:,i*3 + 1], '.--')
     ax3.set_xlabel('x (m)')
     ax3.set_ylabel('y (m)')
-    ax3.grid(b=True, which='major', color='0.65', linestyle='-')
+    # b no longer a valid keyword -- what replaced it???
+
+    ax3.grid(which='major', color='0.65', linestyle='-')
 
     # M-s plane
     ax4 = plt.subplot(224)
     ax4.plot(s, M)
     ax4.set_xlabel('s (m)')
     ax4.set_ylabel('M (kg)')
-    ax4.grid(b=True, which='major', color='0.65', linestyle='-')
+    # b no longer a valid keyword -- what replaced it???
+
+    ax4.grid(which='major', color='0.65', linestyle='-')
 
     plt.draw()
 
@@ -3029,7 +3036,9 @@ def plot_all_variables(t, q, q_local, profile, p, particles,
     ax1.invert_yaxis()
     ax1.set_xlabel('x (m)')
     ax1.set_ylabel('z (m)')
-    ax1.grid(b=True, which='major', color='0.5', linestyle='-')
+    # b no longer a valid keyword -- what replaced it???
+
+    ax1.grid(which='major', color='0.5', linestyle='-')
 
     ax2 = plt.subplot(222)
     ax2.plot(y, z, 'b-')
@@ -3049,7 +3058,9 @@ def plot_all_variables(t, q, q_local, profile, p, particles,
     ax2.invert_yaxis()
     ax2.set_xlabel('y (m)')
     ax2.set_ylabel('z (m)')
-    ax2.grid(b=True, which='major', color='0.5', linestyle='-')
+    # b no longer a valid keyword -- what replaced it???
+
+    ax2.grid(which='major', color='0.5', linestyle='-')
     
     ax3 = plt.subplot(223)
     ax3.plot(x, y, 'b-')
@@ -3068,7 +3079,9 @@ def plot_all_variables(t, q, q_local, profile, p, particles,
                          '.:')
     ax3.set_xlabel('x (m)')
     ax3.set_ylabel('y (m)')
-    ax3.grid(b=True, which='major', color='0.5', linestyle='-')
+    # b no longer a valid keyword -- what replaced it???
+
+    ax3.grid(which='major', color='0.5', linestyle='-')
     
     ax4 = plt.subplot(224)
     ax4.plot(s, np.zeros(s.shape), 'b-')
@@ -3076,7 +3089,9 @@ def plot_all_variables(t, q, q_local, profile, p, particles,
     ax4.plot(s, -b, 'b--')
     ax4.set_xlabel('s (m)')
     ax4.set_ylabel('r (m)')
-    ax4.grid(b=True, which='major', color='0.5', linestyle='-')
+        # b no longer a valid keyword -- what replaced it???
+
+    ax4.grid(which='major', color='0.5', linestyle='-')
     
     plt.tight_layout()
     plt.draw()
@@ -3091,13 +3106,15 @@ def plot_all_variables(t, q, q_local, profile, p, particles,
     ax1.plot(s, h, 'b-')
     ax1.set_xlabel('s (m)')
     ax1.set_ylabel('h (m)')
-    ax1.grid(b=True, which='major', color='0.5', linestyle='-')
+    # b no longer a valid keyword -- what replaced it???
+    ax1.grid(which='major', color='0.5', linestyle='-')
 
     ax2 = plt.subplot(122)
     ax2.plot(s, E, 'b-')
     ax2.set_xlabel('s (m)')
     ax2.set_ylabel('E (kg/s)')
-    ax2.grid(b=True, which='major', color='0.5', linestyle='-')
+    # b no longer a valid keyword -- what replaced it???
+    ax2.grid(which='major', color='0.5', linestyle='-')
 
     plt.draw()
 
@@ -3112,25 +3129,29 @@ def plot_all_variables(t, q, q_local, profile, p, particles,
     ax1.plot(s, ua, 'g--')
     ax1.set_xlabel('s (m)')
     ax1.set_ylabel('u (m/s)')
-    ax1.grid(b=True, which='major', color='0.5', linestyle='-')
+    # b no longer a valid keyword -- what replaced it???
+    ax1.grid(which='major', color='0.5', linestyle='-')
 
     ax2 = plt.subplot(222)
     ax2.plot(s, v, 'b-')
     ax2.set_xlabel('s (m)')
     ax2.set_ylabel('v (m/s)')
-    ax2.grid(b=True, which='major', color='0.5', linestyle='-')
+    # b no longer a valid keyword -- what replaced it???
+    ax2.grid(which='major', color='0.5', linestyle='-')
 
     ax3 = plt.subplot(223)
     ax3.plot(s, w, 'b-')
     ax3.set_xlabel('s (m)')
     ax3.set_ylabel('w (m/s)')
-    ax3.grid(b=True, which='major', color='0.5', linestyle='-')
+    # b no longer a valid keyword -- what replaced it???
+    ax3.grid(which='major', color='0.5', linestyle='-')
 
     ax4 = plt.subplot(224)
     ax4.plot(s, V, 'b-')
     ax4.set_xlabel('s (m)')
     ax4.set_ylabel('V (m/s)')
-    ax4.grid(b=True, which='major', color='0.5', linestyle='-')
+    # b no longer a valid keyword -- what replaced it???
+    ax4.grid(which='major', color='0.5', linestyle='-')
 
     plt.draw()
 
@@ -3149,7 +3170,8 @@ def plot_all_variables(t, q, q_local, profile, p, particles,
         ax1.set_ylim([S[0] - 1, S[0] + 1])
     ax1.set_xlabel('s (m)')
     ax1.set_ylabel('Salinity (psu)')
-    ax1.grid(b=True, which='major', color='0.5', linestyle='-')
+    # b no longer a valid keyword -- what replaced it???
+    ax1.grid(which='major', color='0.5', linestyle='-')
 
     ax2 = plt.subplot(222)
     ax2.yaxis.set_major_formatter(formatter)
@@ -3159,7 +3181,8 @@ def plot_all_variables(t, q, q_local, profile, p, particles,
         ax2.set_ylim([T[0] - 273.15 - 1., T[0] - 273.15 + 1.])
     ax2.set_xlabel('s (m)')
     ax2.set_ylabel('Temperature (deg C)')
-    ax2.grid(b=True, which='major', color='0.5', linestyle='-')
+    # b no longer a valid keyword -- what replaced it???
+    ax2.grid(which='major', color='0.5', linestyle='-')
 
     ax3 = plt.subplot(223)
     ax3.yaxis.set_major_formatter(formatter)
@@ -3169,7 +3192,8 @@ def plot_all_variables(t, q, q_local, profile, p, particles,
         ax3.set_ylim([rho[0] - 1, rho[0] + 1])
     ax3.set_xlabel('s (m)')
     ax3.set_ylabel('Density (kg/m^3)')
-    ax3.grid(b=True, which='major', color='0.5', linestyle='-')
+    # b no longer a valid keyword -- what replaced it???
+    ax3.grid(which='major', color='0.5', linestyle='-')
 
     plt.draw()
 
@@ -3186,14 +3210,15 @@ def plot_all_variables(t, q, q_local, profile, p, particles,
         ax1.plot(s, Mp / 1.e-6, 'b-')
         ax1.set_xlabel('s (m)')
         ax1.set_ylabel('m (mg)')
-        ax1.grid(b=True, which='major', color='0.5', linestyle='-')
+        # b no longer a valid keyword -- what replaced it???
+        ax1.grid(which='major', color='0.5', linestyle='-')
 
         ax2 = plt.subplot(122)
         ax2.yaxis.set_major_formatter(formatter)
         ax2.plot(s, Tp - 273.15, 'b-')
         ax2.set_xlabel('s (m)')
         ax2.set_ylabel('Temperature (deg C)')
-        ax2.grid(b=True, which='major', color='0.5', linestyle='-')
+        ax2.grid(which='major', color='0.5', linestyle='-')
 
         plt.draw()
 

--- a/tamoc/bent_plume_model.py
+++ b/tamoc/bent_plume_model.py
@@ -2380,7 +2380,7 @@ class Particle(dispersed_phases.PlumeParticle):
             
             # Only include this particle if in advection-dominated region
             if L > L_D:
-                Cp += md_p / np.float(k) / np.sqrt(4. * np.pi * L * Ua * Et) * \
+                Cp += md_p / np.float64(k) / np.sqrt(4. * np.pi * L * Ua * Et) * \
                     np.exp(-(Ua * H**2) / (4. * Et * L))
         
         # Concentration cannot be higher than saturation

--- a/tamoc/dbm.py
+++ b/tamoc/dbm.py
@@ -56,6 +56,13 @@ try:
 except ImportError:
     from tamoc import dbm_p as dbm_f
 
+# supressing warnings from numpy -- there were lots in this module
+# Note that this probably sets it for the whole process
+# you can use the numpy.errstate context manager at each location
+# but that was getting tedious ...
+np.seterr(divide='ignore', invalid='ignore')
+
+
 class FluidMixture(object):
     """
     Class object for a fluid mixture

--- a/tamoc/dispersed_phases.py
+++ b/tamoc/dispersed_phases.py
@@ -1483,14 +1483,16 @@ def wuest_ic(u_0, particles, lambda_1, lambda_ave, us, rho_p, rho, Q, R,
         """
         # Get the void fraction for the current estimate of the mixture of 
         # dispersed phases and entrained ambient water
-        xi = void_fraction(u, particles, lambda_1, us, Q, R)
-        
-        # Get the mixed-fluid plume density
-        rho_m = np.sum(xi * rho_p) + (1. - np.sum(xi)) * rho
-        
-        # Calculate the deviation from the desired Froude number
-        return Fr_0 - u / np.sqrt(2. * lambda_ave * R * g * 
-                                  (rho - rho_m) / rho_m)
+        with np.errstate(invalid='ignore'): #, divide='ignore'):
+
+            xi = void_fraction(u, particles, lambda_1, us, Q, R)
+
+            # Get the mixed-fluid plume density
+            rho_m = np.sum(xi * rho_p) + (1. - np.sum(xi)) * rho
+
+            # Calculate the deviation from the desired Froude number
+            return Fr_0 - u / np.sqrt(2. * lambda_ave * R * g *
+                                      (rho - rho_m) / rho_m)
     
     return fsolve(residual, u_0)[0]
 

--- a/tamoc/lmp.py
+++ b/tamoc/lmp.py
@@ -261,7 +261,7 @@ def calculate(t0, q0, q0_local, profile, p, particles, derivs, dt_max,
     while r.successful() and not stop:
         
         # Print progress to the screen
-        if np.remainder(np.float(k), psteps) == 0.:
+        if np.remainder(np.float64(k), psteps) == 0.:
             print('    Distance:  %g (m), time:  %g (s), k:  %d' % \
                 (q[-1][10], t[-1], k))
         

--- a/tamoc/psf.py
+++ b/tamoc/psf.py
@@ -561,7 +561,7 @@ def find_de(de, rho_d, rho_c, mu_d, mu_c, sigma, nu_d, nu_c, g, dp, K,
     lam_max = np.pi * de / 2.
     
     # Find the wave length that corresponds to the maximum growth rate
-    delta = 2. * np.finfo(np.float).eps
+    delta = 2. * np.finfo(np.float64).eps
     lam = minimize(grow_time, lam_crit, args=(de, U, nu_c, nu_d,
         sigma, g, dp, rho_c, rho_d, K, c_0),
         bounds=[((1. + delta) * lam_crit, lam_max)]

--- a/tamoc/single_bubble_model.py
+++ b/tamoc/single_bubble_model.py
@@ -636,7 +636,7 @@ def calculate_path(profile, particle, p, y0, delta_t):
         m0 = np.sum(y[0][3:-1])
         mt = np.sum(y[-1][3:-1])
         f = mt / m0
-        if np.remainder(np.float(k), psteps) == 0.:
+        if np.remainder(np.float64(k), psteps) == 0.:
             print('    Depth:  %g (m), t:  %g (s), k: %d, f: %g (--)' %
                 (r.y[2], t[-1], k, f))
 

--- a/tamoc/smp.py
+++ b/tamoc/smp.py
@@ -341,7 +341,7 @@ def calculate(yi, yo, particles, profile, p, neighbor, derivs, z0, y0, zf,
     while r.successful() and not stop:
         
         # Print progress to the screen
-        if np.remainder(np.float(k), psteps) == 0.:
+        if np.remainder(np.float64(k), psteps) == 0.:
             print('    Depth:  %g (m), k: %d' % (z[-1], k))
         
         # Perform one step of the integration
@@ -378,7 +378,7 @@ def calculate(yi, yo, particles, profile, p, neighbor, derivs, z0, y0, zf,
     y = y[rows,:]
     
     # Return the solution
-    if np.remainder(np.float(k), psteps) == 0.:
+    if np.remainder(np.float64(k), psteps) == 0.:
         print('    Depth:  %g (m), k: %d' % (z[-1], k))
     return (z, y)
 

--- a/tamoc/test/test_ambient.py
+++ b/tamoc/test/test_ambient.py
@@ -32,6 +32,7 @@ OUTPUT_DIR = os.path.realpath(os.path.join(os.path.dirname(__file__),'output'))
 if not os.path.exists(OUTPUT_DIR):
     os.mkdir(OUTPUT_DIR)
 
+
 def get_units(data, units, nr, nc, mks_units, ans=None):
     """
     Run the ambient.convert_units function and test that the data are
@@ -784,3 +785,68 @@ def test_profile_deeper():
     assert_approx_equal(N, 0.0006146292892002274, significant=6)
 
     ctd.close_nc()
+
+def test_profile_temp_in_C():
+    """
+    create a profile "from scratch", using temperature units in C
+
+    NOTE: this was a issue we found -- the compute_pressure call was assuming K
+    """
+    num_points = 6
+    depth = np.linspace(0, 50, num_points)  # Meters
+    temperatures = (13.0 - np.linspace(
+        0, 5, num_points)) # C -- arbitrary linear profile
+    salinity = 33.5 + np.linspace(0, 0.5, num_points)  # PSU
+
+    # Format data for sending to ambient module Profile class
+    ctd_data = np.c_[depth, temperatures, salinity]
+
+    ctd_units = ['m', 'deg C', 'psu']
+
+    # Create the profile object
+    profile = ambient.Profile(ctd_data,
+                              ztsp_units=ctd_units,
+                              )
+    # note that units have been convered to K
+    assert profile.get_units(['temperature', 'pressure']) == ['K', 'Pa']
+
+    data = profile.get_values(depth, ['temperature', 'pressure'])
+    temps = data[:, 0]
+    press = data[:, 1]
+
+    assert np.all(temps == temperatures + 273.15)
+
+    # These are NOT checked numbers, but they look "right"
+    # only here to  catch unintentional changes
+    assert np.allclose(press, [
+        101325., 201904.67038744, 302515.35857713, 403156.17149524,
+        503826.19820054, 604524.50876183
+    ])
+
+
+
+def test_compute_pressure_pos_down():
+    """
+    test the compute_pressure method by itself
+
+    this one has depth positive-down, at first index
+    """
+    num_points = 6  # coarse, but for tests ...
+    depth = np.linspace(0, 50, num_points)  # Meters
+
+    temp = (13.0 - np.linspace(
+        0, 5, num_points)) + 273.15  # K -- arbitrary linear profile
+
+    salinity = 33.5 + np.linspace(0, 0.5, num_points)  # PSU
+
+    pressure = ambient.compute_pressure(depth, temp, salinity, 0)
+
+    # pressure should be going up with depth
+    assert np.all(np.diff(pressure) > 0)
+
+    # These are NOT checked numbers, but they look "right"
+    # only here to  catch unintentional changes
+    assert np.allclose(pressure, [
+        101325., 201904.67038744, 302515.35857713, 403156.17149524,
+        503826.19820054, 604524.50876183
+    ])


### PR DESCRIPTION
numpy has deprecated the `float` attribute, which used to be an alias for the built-in float.

I've replaced these with calls to `np.float64`

It runs on numpy 1.25 now

NOTE: I'm getting two test failures, but they are permission errors on writing an output netcdf file -- so I presume unrelated :-)